### PR TITLE
child component onPress event detection

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -116,7 +116,12 @@ export default class Gestures extends Component {
       onStartShouldSetPanResponder: () => true,
       onPanResponderTerminationRequest: () => true,
       onMoveShouldSetPanResponderCapture: (event, { dx, dy }) => (
-        dx !== 0 && dy !== 0
+        (Math.abs(dx) > 1.5 || Math.abs(dy) > 1.5)
+        // dx !== 0 && dy !== 0
+      ),
+      onMoveShouldSetPanResponder: (event, { dx, dy }) => (
+        (Math.abs(dx) > 1.5 || Math.abs(dy) > 1.5)
+        // dx !== 0 && dy !== 0
       ),
     });
   }


### PR DESCRIPTION
Added onPress detection in PanResponder. Initially it wont recognise onPress events within the child contents. #60 